### PR TITLE
Refactor: miner.cpp: Move local variable to the smaller scope where i…

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -129,9 +129,6 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
     unsigned int nBlockMinSize = GetArg("-blockminsize", DEFAULT_BLOCK_MIN_SIZE);
     nBlockMinSize = std::min(nBlockMaxSize, nBlockMinSize);
 
-    // Collect memory pool transactions into the block
-    CAmount nFees = 0;
-
     {
         LOCK2(cs_main, mempool.cs);
         CBlockIndex* pindexPrev = chainActive.Tip();
@@ -217,7 +214,8 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
                 vecPriority.push_back(TxPriority(dPriority, feeRate, &mi->second.GetTx()));
         }
 
-        // Collect transactions into block
+        // Collect memory pool transactions into the block
+        CAmount nFees = 0;
         uint64_t nBlockSize = 1000;
         uint64_t nBlockTx = 0;
         int nBlockSigOps = 100;


### PR DESCRIPTION
…ts needed

I little bit less code, a little bit more readable.
