### PR TITLE
trivial ignore cache/ in .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,5 +111,6 @@ qa/pull-tester/test.*/*
 !src/leveldb*/Makefile
 
 /doc/doxygen/
+cache/
 
 libbitcoinconsensus.pc


### PR DESCRIPTION
Otherwise running `./qa/pull-tester/rpc-tests.sh` is uncconvenient.
