### PR TITLE
[doc] Mention trivial branch for typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ Development process
 Developers work in their own trees, then submit pull requests when they think
 their feature or bug fix is ready.
 
-If it is a simple/trivial/non-controversial change, then one of the Bitcoin
+If it is a simple/non-controversial change, then one of the Bitcoin
 development team members simply pulls it.
+In case the change is as trivial as fixing a typo in a comment, the pull request
+should be filed against [theuni's trivial branch](https://github.com/theuni/bitcoin/tree/trivial-next).
 
 If it is a *more complicated or potentially controversial* change, then the patch
 submitter will be asked to start a discussion (if they haven't already) on the


### PR DESCRIPTION
I remember people were requesting to add this to the readme.
